### PR TITLE
Fix for php warning undefined constants

### DIFF
--- a/notifications/example-script.php
+++ b/notifications/example-script.php
@@ -17,7 +17,7 @@
 /*
 //uncomment this part, if you want repost only notifications with blocks, epochsum, dailysum
 
-	if(!$_POST[msg] or !in_array($_POST[type],array("blocks","epochsum","dailysum")))
+	if(!$_POST['msg'] or !in_array($_POST['type'],array("blocks","epochsum","dailysum")))
 		die();
 */ 
 
@@ -40,7 +40,7 @@
   
 print_r(bot('sendMessage',[
 		 'chat_id'=>-1001308187, // replace with your chat id
-		 'text'=>$_POST[msg],
+		 'text'=>$_POST['msg'],
 		 'parse_mode' => 'HTML'
 ]));
 	


### PR DESCRIPTION
Submitting this update because in php 7.4.3 getting warning that will be an error in future versions regarding `undefined constants`. 

Here is the error:
```
2021/04/11 18:33:11 [error] 39433#39433: *2596 FastCGI sent in stderr: "PHP message: PHP Warning:  Use of undefined constant msg - assumed 'msg' (this will throw an Error in a future version of PHP) in /var/www/html/somephpfile.php on line 21PHP message: PHP Warning:  Use of undefined constant type - assumed 'type' (this will throw an Error in a future version of PHP) in /var/www/html/somephpfile.php on line 21PHP message: PHP Warning:  Use of undefined constant msg - assumed 'msg' (this will throw an Error in a future version of PHP) in /var/www/html/somephpfile.php on line 44" while reading response header from upstream, client: 23.242.228.215, server: adacoinz.com, request: "POST somephpfile.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php7.4-fpm.sock:", host: "adacoinz.com", referrer: "https://adapools.org/"
```